### PR TITLE
Change implementation of AdjGraph

### DIFF
--- a/src/lib/Main_defs.ml
+++ b/src/lib/Main_defs.ml
@@ -253,7 +253,7 @@ let compress file info net cfg fs networkOp =
        Console.show_message (Slicing.printPrefixes slice.Slicing.prefixes)
          Console.T.Green "Checking SRP for prefixes";
        (* find source nodes *)
-       let n = AdjGraph.num_vertices slice.net.graph in
+       let n = AdjGraph.nb_vertex slice.net.graph in
        let sources =
          Slicing.findRelevantNodes (Slicing.partialEvalOverNodes n (oget slice.net.assertion)) in
        (* partially evaluate the functions of the network. *)

--- a/src/lib/Srp.ml
+++ b/src/lib/Srp.ml
@@ -101,7 +101,7 @@ let net_to_srp net ~throw_requires =
   info.a <- (match net.Syntax.assertion with
              | Some a -> get_func a
              | None -> None);
-  info.ns <- Some (AdjGraph.num_vertices net.Syntax.graph);
+  info.ns <- Some (AdjGraph.nb_vertex net.Syntax.graph);
   info.es <- Some (AdjGraph.edges net.Syntax.graph);
   (* process requires *)
   BatList.iter (fun e ->
@@ -136,7 +136,7 @@ let net_to_srp net ~throw_requires =
 
 let net_to_state net ~throw_requires =
   let srp, init, syms = net_to_srp net ~throw_requires in
-  let state = create_state (AdjGraph.num_vertices srp.graph) init in
+  let state = create_state (AdjGraph.nb_vertex srp.graph) init in
   (srp, state, syms)
 
 let solution_to_string s =

--- a/src/lib/compression/Abstraction.ml
+++ b/src/lib/compression/Abstraction.ml
@@ -190,10 +190,10 @@ module BuildAbstractNetwork =
 
     let buildAbstractAdjGraph (g: AdjGraph.t) (f: abstractionMap) : AdjGraph.t =
       let n = size f in
-      let ag = AdjGraph.create ~size:n () in
+      let ag = AdjGraph.create n in
       fold_vertices (fun uhat ag ->
           let es = findAbstractEdges g f uhat in
-          EdgeSet.fold (fun e ag -> AdjGraph.add_edge_e ag e) es ag) n ag
+          EdgeSet.fold (fun e ag -> add_edge_e ag e) es ag) n ag
 
     (* get all the concrete neighbors v of u s.t. f(v) = vhat *)
     let getNeighborsInVhat f g u vhat =
@@ -655,7 +655,7 @@ module FailuresAbstraction =
           let u, todo' = VertexSet.pop_min todo in
           if u <> d then
             begin
-              let (es, sset, tset) =  AdjGraph.min_cut g d u in
+              let (es, sset, tset) =  min_cut g d u in
               if EdgeSet.cardinal es > k then
                 loop todo' cuts new_todo
               else
@@ -960,8 +960,8 @@ module FailuresAbstraction =
                  end
                else (acc, AdjGraph.add_edge_e ag edge)
             | _ -> failwith "This should be a boolean variable") failVars
-                     (EdgeSet.empty, 
-                      AdjGraph.create ~size:(AbstractionMap.size f) ())
+                     (EdgeSet.empty,
+                      AdjGraph.create (AbstractionMap.size f))
       in
 
       (* number of concrete links failed in the network *)

--- a/src/lib/compression/Abstraction.ml
+++ b/src/lib/compression/Abstraction.ml
@@ -387,7 +387,7 @@ module BuildAbstractNetwork =
       let open Slicing in
       let absGraph= buildAbstractAdjGraph slice.net.graph f in
       let edgeshat = AdjGraph.edges absGraph in
-      let n = AdjGraph.num_vertices absGraph in
+      let n = AdjGraph.nb_vertex absGraph in
       (* build the symbolic representation of failures *)
       (*TODO: make this a separate transformation?*)
       let (failuresMap, symbolics, requires) = buildSymbolicFailures edgeshat k in
@@ -400,12 +400,12 @@ module BuildAbstractNetwork =
       in
       (* build the abstract init function *)
       let initMap =
-        Slicing.partialEvalOverNodes (num_vertices slice.net.graph) slice.net.init
+        Slicing.partialEvalOverNodes (AdjGraph.nb_vertex slice.net.graph) slice.net.init
       in
       let inithat = buildAbstractInit slice.destinations initMap slice.net.attr_type f in
       (* build the abstract assert function *)
       let assertMap =
-        Slicing.partialEvalOverNodes (num_vertices slice.net.graph) (Nv_utils.OCamlUtils.oget slice.net.assertion)
+        Slicing.partialEvalOverNodes (AdjGraph.nb_vertex slice.net.graph) (Nv_utils.OCamlUtils.oget slice.net.assertion)
       in
       let asserthat = buildAbstractAssert assertMap f in
       if !debugAbstraction then
@@ -961,7 +961,7 @@ module FailuresAbstraction =
                else (acc, AdjGraph.add_edge_e ag edge)
             | _ -> failwith "This should be a boolean variable") failVars
                      (EdgeSet.empty,
-                      AdjGraph.create (AbstractionMap.size f))
+                      AdjGraph.empty)
       in
 
       (* number of concrete links failed in the network *)
@@ -979,7 +979,7 @@ module FailuresAbstraction =
             AdjGraph.fold_vertices (fun u acc ->
                 if not (validAttribute attrTy (VertexMap.find u sol.labels)) then
                   VertexSet.add u acc
-                else acc) (AdjGraph.num_vertices agraph) VertexSet.empty
+                else acc) (AdjGraph.nb_vertex agraph) VertexSet.empty
           in
           (* and the set of edges that were not used for forwarding even though there
              were no failures *)
@@ -1382,7 +1382,7 @@ module FailuresAbstraction =
          (* for statistics only *)
          (* let ag = BuildAbstractNetwork.buildAbstractAdjGraph g f in *)
          (* let d = getId f (VertexSet.choose ds) in *)
-         (* for u=0 to (AdjGraph.num_vertices ag |> Integer.to_int) do *)
+         (* for u=0 to (AdjGraph.nb_vertex ag |> Integer.to_int) do *)
          (*    let (es, sset, tset) =  min_cut ag d (Integer.of_int u) in *)
          (*      if (EdgeSet.cardinal es > (k+1)) then *)
          (*        Printf.printf "not optimal\n" *)

--- a/src/lib/compression/Abstraction.ml
+++ b/src/lib/compression/Abstraction.ml
@@ -955,7 +955,7 @@ module FailuresAbstraction =
             | VBool b ->
                if b then
                  begin
-                   Printf.printf "Failed Edge: %s\n" (AdjGraph.printEdge edge);
+                   Printf.printf "Failed Edge: %s\n" (Edge.to_string edge);
                    (EdgeSet.add edge acc, AdjGraph.add_edge_e ag edge)
                  end
                else (acc, AdjGraph.add_edge_e ag edge)
@@ -1076,7 +1076,7 @@ module FailuresAbstraction =
             BatList.iter (fun cut ->
                 Printf.printf "min-cut: ";
                 BatList.iter (fun e ->
-                    Printf.printf "%s," (printEdge e))
+                    Printf.printf "%s," (Edge.to_string e))
                   cut;
                 Printf.printf "\n") concrete_cuts;
             raise Cutoff
@@ -1249,7 +1249,7 @@ module FailuresAbstraction =
             BatList.iter (fun cut ->
                 Printf.printf "min-cut: ";
                 BatList.iter (fun e ->
-                    Printf.printf "%s," (printEdge e))
+                    Printf.printf "%s," (Edge.to_string e))
                   cut;
                 Printf.printf "\n") concrete_cuts;
             raise Cutoff

--- a/src/lib/compression/AbstractionMap.ml
+++ b/src/lib/compression/AbstractionMap.ml
@@ -12,8 +12,8 @@ module AbstractNode =
       let rec printAux lst acc =
         match lst with
         | [] -> "}" :: acc
-        | [u] -> printAux [] ((Printf.sprintf "%s" (Vertex.printVertex u)) :: acc)
-        | u :: lst -> printAux lst ((Printf.sprintf "%s," (Vertex.printVertex u)) :: acc)
+        | [u] -> printAux [] ((Printf.sprintf "%s" (Vertex.to_string u)) :: acc)
+        | u :: lst -> printAux lst ((Printf.sprintf "%s," (Vertex.to_string u)) :: acc)
       in
       String.concat "" (BatList.rev (printAux (VertexSet.elements us) ["{"]))
 

--- a/src/lib/datastructures/AdjGraph.ml
+++ b/src/lib/datastructures/AdjGraph.ml
@@ -1,9 +1,6 @@
 open Graph
 
-(* include Pack.Graph *)
-
 module Vertex = struct
-  (* include Pack.Graph.V *)
   type t = int (* Really should be Syntax.node, but that causes a dependency loop *)
 
   let printVertex i =

--- a/src/lib/datastructures/AdjGraph.ml
+++ b/src/lib/datastructures/AdjGraph.ml
@@ -46,7 +46,7 @@ let print_vertex_map elem_to_string m =
 
 (* vertices and edges *)
 let get_vertices (g: t) =
-  fold_vertex (fun v acc -> VertexSet.add v acc) g VertexSet.empty
+  fold_vertex VertexSet.add g VertexSet.empty
 
 let fold_vertices (f: Vertex.t -> 'a -> 'a) i (acc: 'a) : 'a =
   let rec loop j =
@@ -69,19 +69,17 @@ let good_vertex g v =
 let neighbors g v =
   good_vertex g v ;
   (* collect all successors and predecessors, ignoring duplicates *)
-  let succs = fold_succ (fun u s -> BatSet.add u s) g v BatSet.empty
+  let succs = fold_succ BatSet.add g v BatSet.empty
     in
-    let all_nbrs = fold_pred (fun u s -> BatSet.add u s) g v succs
+    let all_nbrs = fold_pred BatSet.add g v succs
       in
       BatSet.elements all_nbrs
   (* succ g v pred g v *)
   (* match find_opt v m with None -> [] | Some ns -> ns *)
 
 let edges (g: t) =
-  let append_edge u v acc = (u, v) :: acc
-  in
   BatList.rev
-    (fold_edges append_edge g [])
+    (fold_edges_e List.cons g [])
 
 let of_edges (l: (Vertex.t * Vertex.t) list) : t =
   let g = empty in

--- a/src/lib/datastructures/AdjGraph.ml
+++ b/src/lib/datastructures/AdjGraph.ml
@@ -3,7 +3,7 @@ open Graph
 module Vertex = struct
   type t = int (* Really should be Syntax.node, but that causes a dependency loop *)
 
-  let printVertex i =
+  let to_string i =
     Printf.sprintf "%d" i
 
   let compare = Pervasives.compare
@@ -35,13 +35,13 @@ module EdgeMap = BatMap.Make(Edge)
 let vertex_map_to_string elem_to_string m =
   let kvs = VertexMap.fold (fun k v l -> (k, v) :: l) m [] in
   BatList.fold_left
-    (fun s (k, v) -> (Vertex.printVertex k) ^ ":" ^ elem_to_string v ^ s)
+    (fun s (k, v) -> (Vertex.to_string k) ^ ":" ^ elem_to_string v ^ s)
     "" kvs
 
 let print_vertex_map elem_to_string m =
   VertexMap.iter
     (fun k v ->
-      print_endline (Vertex.printVertex k ^ ":" ^ elem_to_string v) )
+      print_endline (Vertex.to_string k ^ ":" ^ elem_to_string v) )
     m
 
 (* vertices and edges *)
@@ -63,7 +63,7 @@ exception BadVertex of Vertex.t
 
 let good_vertex g v = 
   if not (mem_vertex g v)
-  then (Printf.printf "bad: %s" (Vertex.printVertex v); raise (BadVertex v))
+  then (Printf.printf "bad: %s" (Vertex.to_string v); raise (BadVertex v))
 
 (* out-neighbors of v in g *)
 let neighbors = succ
@@ -98,7 +98,7 @@ let print g =
   Printf.printf "%d\n" (nb_vertex g) ;
   BatList.iter
     (fun (v, w) ->
-      Printf.printf "%s -> %s\n" (Vertex.printVertex v) (Vertex.printVertex w)
+      Printf.printf "%s -> %s\n" (Vertex.to_string v) (Vertex.to_string w)
       )
     (edges g)
 
@@ -109,7 +109,7 @@ let to_string g =
     | [] -> ()
     | (v, w) :: rest ->
         Buffer.add_string b
-          (Printf.sprintf "%s -> %s\n" (Vertex.printVertex v) (Vertex.printVertex w)) ;
+          (Printf.sprintf "%s -> %s\n" (Vertex.to_string v) (Vertex.to_string w)) ;
         add_edges rest
   in
   Buffer.add_string b (string_of_int (nb_vertex g) ^ "\n") ;
@@ -206,9 +206,9 @@ module DrawableGraph = struct
                    let default_edge_attributes _ = []
                    let get_subgraph _ = None
                    let vertex_attributes v =
-                     let label = Vertex.printVertex v in
+                     let label = Vertex.to_string v in
                      [`Shape `Circle; `Label label; `Fontsize 11;]
-                   let vertex_name v = Vertex.printVertex v
+                   let vertex_name v = Vertex.to_string v
                    let default_vertex_attributes _ = []
                    let graph_attributes _ = [`Center true; `Nodesep 0.45;
                                              `Ranksep 0.45; `Size (82.67, 62.42)]

--- a/src/lib/datastructures/AdjGraph.ml
+++ b/src/lib/datastructures/AdjGraph.ml
@@ -1,3 +1,5 @@
+open Graph
+
 module Vertex = struct
   type t = int (* Really should be Syntax.node, but that causes a dependency loop *)
 
@@ -21,6 +23,8 @@ module Edge = struct
     if Pervasives.compare v1 v2 <> 0 then Pervasives.compare v1 v2
     else Pervasives.compare w1 w2
 end
+
+include Imperative.Graph.Concrete(Vertex)
 
 let printEdge (e : Edge.t) =
   Printf.sprintf "<%d,%d>" (fst e) (snd e);

--- a/src/lib/datastructures/AdjGraph.ml
+++ b/src/lib/datastructures/AdjGraph.ml
@@ -65,17 +65,8 @@ let good_vertex g v =
   if not (mem_vertex g v)
   then (Printf.printf "bad: %s" (Vertex.printVertex v); raise (BadVertex v))
 
-(* neighbors of v in g *)
-let neighbors g v =
-  good_vertex g v ;
-  (* collect all successors and predecessors, ignoring duplicates *)
-  let succs = fold_succ BatSet.add g v BatSet.empty
-    in
-    let all_nbrs = fold_pred BatSet.add g v succs
-      in
-      BatSet.elements all_nbrs
-  (* succ g v pred g v *)
-  (* match find_opt v m with None -> [] | Some ns -> ns *)
+(* out-neighbors of v in g *)
+let neighbors = succ
 
 let edges (g: t) =
   BatList.rev

--- a/src/lib/datastructures/AdjGraph.ml
+++ b/src/lib/datastructures/AdjGraph.ml
@@ -71,21 +71,18 @@ let good_vertex g v =
 (* out-neighbors of v in g *)
 let neighbors = succ
 
+(* list of edges in graph g *)
 let edges (g: t) =
   BatList.rev
     (fold_edges_e List.cons g [])
 
 let of_edges (l: (Vertex.t * Vertex.t) list) : t =
   let g = empty in
-    BatList.fold_left (fun g (u, v) -> add_edge g u v) g l
+    BatList.fold_left (fun g e -> add_edge_e g e) g l
 
-(* return a VertexMap where each vertex key has a map of edge neighbors *)
-let edges_map (g: t) (f: Edge.t -> 'a) =
-  (* create an EdgeMap containing all neighbors of u *)
-  let my_edges v neighbors a =
-    BatList.fold_left (fun a w -> EdgeMap.add (v, w) (f (v, w)) a) a neighbors
-  in
-  fold_vertex (fun v a -> my_edges v (neighbors g v) a) g EdgeMap.empty
+(* return an EdgeMap where each edge key has a map of edge neighbors *)
+let edges_map (g: t) (f: Edge.t -> 'a) : 'a EdgeMap.t =
+  fold_edges_e (fun e a -> EdgeMap.add e (f e) a) g EdgeMap.empty
 
 let rec add_edges g edges =
   match edges with

--- a/src/lib/datastructures/AdjGraph.ml
+++ b/src/lib/datastructures/AdjGraph.ml
@@ -125,7 +125,7 @@ let bfs (g: t) (rg : int EdgeMap.t) (s: Vertex.t) (t: Vertex.t) =
     if not (Queue.is_empty q) then
       begin
         let u = Queue.pop q in
-        let vs = neighbors g u in
+        let vs = succ g u in
         let visited, path =
           BatList.fold_left (fun (accvs, accpath) (v: Vertex.t) ->
               if ((not (VertexSet.mem v accvs)) && (EdgeMap.find (u,v) rg > 0)) then
@@ -146,7 +146,7 @@ let bfs (g: t) (rg : int EdgeMap.t) (s: Vertex.t) (t: Vertex.t) =
 let dfs (g: t) (rg : int EdgeMap.t) (s: Vertex.t) =
   let rec loop u visited =
     let visited = VertexSet.add u visited in
-    let vs = neighbors g u in
+    let vs = succ g u in
     BatList.fold_left (fun accvs v ->
         if ((EdgeMap.find (u,v) rg > 0) && (not (VertexSet.mem v accvs))) then
           loop v accvs

--- a/src/lib/datastructures/AdjGraph.ml
+++ b/src/lib/datastructures/AdjGraph.ml
@@ -12,7 +12,7 @@ module Vertex = struct
   let hash = Hashtbl.hash
 end
 
-include Persistent.Graph.Concrete(Vertex)
+include Persistent.Digraph.Concrete(Vertex)
 
 module VertexMap = BetterMap.Make (Vertex)
 module VertexSet = BetterSet.Make(Vertex)
@@ -197,7 +197,7 @@ module DrawableGraph = struct
     incr counter;
     file ^ "-" ^ (string_of_int k) ^ "-" ^ (string_of_int !counter)
 
-  module G = Graph.Persistent.Graph.Concrete (Vertex)
+  module G = Graph.Persistent.Digraph.Concrete (Vertex)
 
   module Dot = Graph.Graphviz.Dot(struct
                    include G

--- a/src/lib/datastructures/AdjGraph.ml
+++ b/src/lib/datastructures/AdjGraph.ml
@@ -24,15 +24,7 @@ let create_vertices (i: int) =
   let e = 0 -- i in
     BatEnum.fold (fun acc v -> VertexSet.add v acc) VertexSet.empty e
 
-module Edge = struct
-  type t = Vertex.t * Vertex.t
-
-  let src = fst
-  let dst = snd
-  let compare (v1, w1) (v2, w2) =
-    if Pervasives.compare v1 v2 <> 0 then Pervasives.compare v1 v2
-    else Pervasives.compare w1 w2
-end
+module Edge = E
 
 let printEdge (e : Edge.t) =
   Printf.sprintf "<%d,%d>" (Edge.src e) (Edge.dst e);
@@ -52,12 +44,7 @@ let print_vertex_map elem_to_string m =
       print_endline (Vertex.printVertex k ^ ":" ^ elem_to_string v) )
     m
 
-(* a graph as ajacency list * # of vertices *)
-(* type t = Vertex.t list VertexMap.t * int *)
-
 (* vertices and edges *)
-let num_vertices = nb_vertex
-
 let get_vertices (g: t) =
   fold_vertex (fun v acc -> VertexSet.add v acc) g VertexSet.empty
 
@@ -70,11 +57,6 @@ let fold_vertices (f: Vertex.t -> 'a -> 'a) i (acc: 'a) : 'a =
 
 let create i =
   fold_vertices (fun v g -> add_vertex g v) i empty
-
-(* get_vertices now returns all the vertices in the graph, not just
-   the ones that have an outgoing edge.*)
-(* let get_vertices (_, i) = *)
-(*   VertexSet.of_enum (BatEnum.(--) 0 i) *)
 
 let edges (g: t) =
   let append_edge u v acc = (u, v) :: acc
@@ -95,7 +77,6 @@ let edges_map (g: t) (f: Edge.t -> 'a) =
 exception BadVertex of Vertex.t
 
 let good_vertex g v = 
-  (* if Pervasives.compare v 0 < 0 || not (Pervasives.compare (nb_vertex g) v > 0) *)
   if not (mem_vertex g v)
   then (Printf.printf "bad: %s" (Vertex.printVertex v); raise (BadVertex v))
 
@@ -104,56 +85,10 @@ let good_graph g =
     (fun (v, w) -> good_vertex g v ; good_vertex g w)
     (edges g)
 
-(* add_edge g e adds directed edge e to g *)
-(* let add_edge (m, i) (v, w) = *)
-(*   good_vertex (m, i) v ; *)
-(*   good_vertex (m, i) w ; *)
-(*   let f adj = *)
-(*     match adj with *)
-(*     | None -> Some [w] *)
-(*     | Some ns -> if BatList.mem w ns then adj else Some (w :: ns) *)
-(*   in *)
-(*   (update v f m, i) *)
-
 let rec add_edges g edges =
   match edges with
   | [] -> g
   | e :: edges -> add_edges (add_edge_e g e) edges
-
-(* add_edge g e adds directed edge e to g *)
-(* let remove_edge (m, i) (v, w) = *)
-(*   good_vertex (m, i) v ; *)
-(*   good_vertex (m, i) w ; *)
-(*   let f adj = *)
-(*     match adj with *)
-(*     | None -> adj *)
-(*     | Some ns -> *)
-(*       match *)
-(*         BatList.filter (fun a -> not (a = w)) ns *)
-(*       with *)
-(*       | [] -> None *)
-(*       | ns' -> Some ns' *)
-(*   in *)
-(*   (update v f m, i) *)
-
-(* let remove_edges (m, i) (es: EdgeSet.t) = *)
-(*   let umap = EdgeSet.fold (fun (u,v) acc -> *)
-(*                  VertexMap.modify_def (VertexSet.empty) u *)
-(*                                       (fun vs -> VertexSet.add v vs) acc) *)
-(*                           es VertexMap.empty *)
-(*   in *)
-(*   let f vs adj = *)
-(*     match adj with *)
-(*     | None -> adj *)
-(*     | Some ns -> *)
-(*       match *)
-(*         BatList.filter (fun a -> not (VertexSet.mem a vs)) ns *)
-(*       with *)
-(*       | [] -> None *)
-(*       | ns' -> Some ns' *)
-(*   in *)
-(*   let m' = VertexMap.fold (fun u vs acc -> update u (f vs) acc) umap m in *)
-(*   (m', i) *)
 
 (* neighbors of v in g *)
 let neighbors g v =
@@ -256,13 +191,6 @@ let min_cut (g: t) s t =
   in
   (cut, visited, VertexSet.diff (get_vertices g) visited)
 
-(*
-module BoolOrdered = struct
-  type t = bool
-  let default = false
-  let compare = compare
-end *)
-
 module DrawableGraph = struct
 
   let graph_dot_file =
@@ -272,13 +200,6 @@ module DrawableGraph = struct
     file ^ "-" ^ (string_of_int k) ^ "-" ^ (string_of_int !counter)
 
   module G = Graph.Persistent.Graph.Concrete (Vertex)
-  (* module G = Pack.Graph *)
-
-(*   let createGraph ((m,_): t)  = *)
-(*     (1* Assume no vertices of degree 0 *1) *)
-(*     VertexMap.fold (fun u es acc -> *)
-(*         BatList.fold_left (fun acc v -> *)
-(*             G.add_edge_e acc (G.E.create u () v)) acc es) m G.empty *)
 
   module Dot = Graph.Graphviz.Dot(struct
                    include G

--- a/src/lib/datastructures/AdjGraph.ml
+++ b/src/lib/datastructures/AdjGraph.ml
@@ -1,4 +1,5 @@
 open Graph
+open Nv_utils.PrimitiveCollections
 
 module Vertex = struct
   type t = int (* Really should be Syntax.node, but that causes a dependency loop *)
@@ -13,10 +14,10 @@ end
 
 include Persistent.Graph.Concrete(Vertex)
 
-module VertexMap = BatMap.Make (Vertex)
-module VertexSet = BatSet.Make(Vertex)
-module VertexSetSet : BatSet.S with type elt = VertexSet.t = BatSet.Make(VertexSet)
-module VertexSetMap : BatMap.S with type key = VertexSet.t = BatMap.Make(VertexSet)
+module VertexMap = BetterMap.Make (Vertex)
+module VertexSet = BetterSet.Make(Vertex)
+module VertexSetSet : BetterSet.S with type elt = VertexSet.t = BetterSet.Make(VertexSet)
+module VertexSetMap : BetterMap.S with type key = VertexSet.t = BetterMap.Make(VertexSet)
 
 let create_vertices (i: int) =
   let open Batteries in
@@ -24,13 +25,15 @@ let create_vertices (i: int) =
   let e = 0 -- i in
     BatEnum.fold (fun acc v -> VertexSet.add v acc) VertexSet.empty e
 
-module Edge = E
+module Edge = struct
+  include E
 
-let printEdge (e : Edge.t) =
-  Printf.sprintf "<%d,%d>" (Edge.src e) (Edge.dst e);
+  let to_string e =
+    Printf.sprintf "<%s,%s>" (Vertex.to_string (src e)) (Vertex.to_string (dst e))
+end
 
-module EdgeSet = BatSet.Make(Edge)
-module EdgeMap = BatMap.Make(Edge)
+module EdgeSet = BetterSet.Make(Edge)
+module EdgeMap = BetterMap.Make(Edge)
 
 let vertex_map_to_string elem_to_string m =
   let kvs = VertexMap.fold (fun k v l -> (k, v) :: l) m [] in

--- a/src/lib/datastructures/AdjGraph.mli
+++ b/src/lib/datastructures/AdjGraph.mli
@@ -2,7 +2,7 @@ module Vertex :
   sig
     type t = int (* Really should be Syntax.node, but that causes a dependency loop *)
 
-    val printVertex : t -> string
+    val to_string : t -> string
     val compare : t -> t -> int
     val equal : t -> t -> bool
     val hash : t -> int
@@ -11,9 +11,11 @@ module Vertex :
 (* graph *)
 include module type of Graph.Persistent.Graph.Concrete (Vertex)
 
-module Edge = E
-
-val printEdge : Edge.t -> string
+module Edge :
+  sig
+    include module type of E
+    val to_string : t -> string
+  end
 
 module VertexMap : BatMap.S with type key = Vertex.t
 

--- a/src/lib/datastructures/AdjGraph.mli
+++ b/src/lib/datastructures/AdjGraph.mli
@@ -1,7 +1,6 @@
 
 module Vertex :
   sig
-    (* include module type of Graph.Pack.Graph.V *)
     type t = int (* Really should be Syntax.node, but that causes a dependency loop *)
 
     val printVertex : t -> string
@@ -59,24 +58,11 @@ val get_vertices : t -> VertexSet.t
 
 val edges : t -> (Vertex.t * Vertex.t) list
 
-(* add_edge g e adds directed edge e to g *)
-
-(* val add_edge : t -> Edge.t -> t *)
-
 (* of_edges l creates a new graph with all nodes and edges given in l *)
 val of_edges : (Vertex.t * Vertex.t) list -> t
 
 (* add_edges g l adds all directed edges in l to g *)
 val add_edges : t -> Edge.t list -> t
-
-(* add_edge g e adds directed edge e to g *)
-
-(* val remove_edge : t -> Edge.t -> t *)
-
-(** Removes multiple edges from the graph. More efficient, than
-   multiple calls to remove_edge. Does not raise BadVertex if an edge
-   is invalid! *)
-(* val remove_edges : t -> EdgeSet.t -> t *)
 
 (* neighbors g v returns neighbors of v in g; raise BadVertex if v invalid *)
 

--- a/src/lib/datastructures/AdjGraph.mli
+++ b/src/lib/datastructures/AdjGraph.mli
@@ -4,6 +4,9 @@ module Vertex :
 
     val printVertex : t -> string
     val compare : t -> t -> int
+    val equal : t -> t -> bool
+    val hash : t -> int
+    val of_int : int -> t
   end
 
 module Edge : Map.OrderedType with type t = Vertex.t * Vertex.t
@@ -16,6 +19,9 @@ module VertexSet : BatSet.S with type elt = Vertex.t
 module VertexSetSet : BatSet.S with type elt = VertexSet.t
 module VertexSetMap : BatMap.S with type key = VertexSet.t
 
+(** Create an incrementing set of vertices given an integer *)
+val create_vertices : int -> VertexSet.t
+
 module EdgeSet : BatSet.S with type elt = Edge.t
 
 module EdgeMap : BatMap.S with type key = Edge.t
@@ -27,8 +33,8 @@ val vertex_map_to_string : ('a -> string) -> 'a VertexMap.t -> string
 val print_vertex_map : ('a -> string) -> 'a VertexMap.t -> unit
 
 (* graph *)
-
-type t
+(* include module type of Graph.Persistent.Graph.Concrete (Vertex) *)
+include module type of Graph.Pack.Graph
 
 (* raise BadVertex if a vertex v does not belong to a graph's set of vertices, ie: 0..num_vertex-1 *)
 
@@ -39,17 +45,16 @@ val good_vertex : t -> Vertex.t -> unit
 val good_graph : t -> unit
 
 (* create a graph with i vertices named 0..i-1 *)
-
 (* val create : int -> t *)
 
 (* number of vertices in the graph (named 0..i-1) *)
 
-(* val num_vertices : t -> int *)
+val num_vertices : t -> int
 
 val fold_vertices : (Vertex.t -> 'a -> 'a) -> Vertex.t -> 'a -> 'a
 
 (** Vertices in the adjacency graph *)
-(* val get_vertices : t -> VertexSet.t *)
+val get_vertices : t -> VertexSet.t
 
 (* edges in the graph *)
 
@@ -59,9 +64,11 @@ val edges : t -> (Vertex.t * Vertex.t) list
 
 (* val add_edge : t -> Edge.t -> t *)
 
-(* add_edge g l adds all directed edges in l to g *)
+(* of_edges l creates a new graph with all nodes and edges given in l *)
+val of_edges : (Vertex.t * Vertex.t) list -> t
 
-(* val add_edges : t -> Edge.t list -> t *)
+(* add_edges g l adds all directed edges in l to g *)
+val add_edges : t -> Edge.t list -> t
 
 (* add_edge g e adds directed edge e to g *)
 
@@ -85,7 +92,7 @@ val print : t -> unit
 val to_string : t -> string
 
 (** computes min-cut between s and t and the returns the min-cut and the S and T sets *)
-(* val min_cut : t -> Vertex.t -> Vertex.t -> EdgeSet.t * VertexSet.t * VertexSet.t *)
+val min_cut : t -> Vertex.t -> Vertex.t -> EdgeSet.t * VertexSet.t * VertexSet.t
 
 module DrawableGraph :
 sig

--- a/src/lib/datastructures/AdjGraph.mli
+++ b/src/lib/datastructures/AdjGraph.mli
@@ -1,4 +1,3 @@
-
 module Vertex :
   sig
     type t = int (* Really should be Syntax.node, but that causes a dependency loop *)
@@ -12,7 +11,7 @@ module Vertex :
 (* graph *)
 include module type of Graph.Persistent.Graph.Concrete (Vertex)
 
-module Edge : Map.OrderedType with type t = Vertex.t * Vertex.t
+module Edge = E
 
 val printEdge : Edge.t -> string
 
@@ -21,9 +20,6 @@ module VertexMap : BatMap.S with type key = Vertex.t
 module VertexSet : BatSet.S with type elt = Vertex.t
 module VertexSetSet : BatSet.S with type elt = VertexSet.t
 module VertexSetMap : BatMap.S with type key = VertexSet.t
-
-(** Create an incrementing set of vertices given an integer *)
-val create_vertices : int -> VertexSet.t
 
 module EdgeSet : BatSet.S with type elt = Edge.t
 
@@ -36,7 +32,6 @@ val vertex_map_to_string : ('a -> string) -> 'a VertexMap.t -> string
 val print_vertex_map : ('a -> string) -> 'a VertexMap.t -> unit
 
 (* raise BadVertex if a vertex v does not belong to a graph's set of vertices, ie: 0..num_vertex-1 *)
-
 exception BadVertex of Vertex.t
 
 val good_vertex : t -> Vertex.t -> unit
@@ -46,34 +41,31 @@ val good_graph : t -> unit
 (* create a graph with i vertices named 0..i-1 *)
 val create : int -> t
 
-(* number of vertices in the graph (named 0..i-1) *)
-val num_vertices : t -> int
+(** Create an incrementing set of vertices given an integer *)
+val create_vertices : int -> VertexSet.t
 
+(** fold over a set of vertices from 0 to i-1 *)
 val fold_vertices : (Vertex.t -> 'a -> 'a) -> Vertex.t -> 'a -> 'a
 
 (** Vertices in the adjacency graph *)
 val get_vertices : t -> VertexSet.t
 
-(* edges in the graph *)
-
+(** edges in the graph *)
 val edges : t -> (Vertex.t * Vertex.t) list
 
-(* of_edges l creates a new graph with all nodes and edges given in l *)
+(** of_edges l creates a new graph with all nodes and edges given in l *)
 val of_edges : (Vertex.t * Vertex.t) list -> t
 
-(* add_edges g l adds all directed edges in l to g *)
+(** add_edges g l adds all directed edges in l to g *)
 val add_edges : t -> Edge.t list -> t
 
-(* neighbors g v returns neighbors of v in g; raise BadVertex if v invalid *)
-
+(** neighbors g v returns neighbors of v in g; raise BadVertex if v invalid *)
 val neighbors : t -> Vertex.t -> Vertex.t list
 
-(* print graph *)
-
+(** print graph *)
 val print : t -> unit
 
-(* graph to string *)
-
+(** graph to string *)
 val to_string : t -> string
 
 (** computes min-cut between s and t and the returns the min-cut and the S and T sets *)

--- a/src/lib/datastructures/AdjGraph.mli
+++ b/src/lib/datastructures/AdjGraph.mli
@@ -40,17 +40,16 @@ val good_graph : t -> unit
 
 (* create a graph with i vertices named 0..i-1 *)
 
-val create : int -> t
+(* val create : int -> t *)
 
 (* number of vertices in the graph (named 0..i-1) *)
 
-val num_vertices : t -> int
-
+(* val num_vertices : t -> int *)
 
 val fold_vertices : (Vertex.t -> 'a -> 'a) -> Vertex.t -> 'a -> 'a
 
 (** Vertices in the adjacency graph *)
-val get_vertices : t -> VertexSet.t
+(* val get_vertices : t -> VertexSet.t *)
 
 (* edges in the graph *)
 
@@ -58,20 +57,20 @@ val edges : t -> (Vertex.t * Vertex.t) list
 
 (* add_edge g e adds directed edge e to g *)
 
-val add_edge : t -> Edge.t -> t
+(* val add_edge : t -> Edge.t -> t *)
 
 (* add_edge g l adds all directed edges in l to g *)
 
-val add_edges : t -> Edge.t list -> t
+(* val add_edges : t -> Edge.t list -> t *)
 
 (* add_edge g e adds directed edge e to g *)
 
-val remove_edge : t -> Edge.t -> t
+(* val remove_edge : t -> Edge.t -> t *)
 
 (** Removes multiple edges from the graph. More efficient, than
    multiple calls to remove_edge. Does not raise BadVertex if an edge
    is invalid! *)
-val remove_edges : t -> EdgeSet.t -> t
+(* val remove_edges : t -> EdgeSet.t -> t *)
 
 (* neighbors g v returns neighbors of v in g; raise BadVertex if v invalid *)
 
@@ -86,7 +85,7 @@ val print : t -> unit
 val to_string : t -> string
 
 (** computes min-cut between s and t and the returns the min-cut and the S and T sets *)
-val min_cut : t -> Vertex.t -> Vertex.t -> EdgeSet.t * VertexSet.t * VertexSet.t
+(* val min_cut : t -> Vertex.t -> Vertex.t -> EdgeSet.t * VertexSet.t * VertexSet.t *)
 
 module DrawableGraph :
 sig

--- a/src/lib/datastructures/AdjGraph.mli
+++ b/src/lib/datastructures/AdjGraph.mli
@@ -9,7 +9,7 @@ module Vertex :
   end
 
 (* graph *)
-include module type of Graph.Persistent.Graph.Concrete (Vertex)
+include module type of Graph.Persistent.Digraph.Concrete (Vertex)
 
 module Edge :
   sig

--- a/src/lib/datastructures/AdjGraph.mli
+++ b/src/lib/datastructures/AdjGraph.mli
@@ -53,10 +53,10 @@ val fold_vertices : (Vertex.t -> 'a -> 'a) -> Vertex.t -> 'a -> 'a
 val get_vertices : t -> VertexSet.t
 
 (** edges in the graph *)
-val edges : t -> (Vertex.t * Vertex.t) list
+val edges : t -> Edge.t list
 
 (** of_edges l creates a new graph with all nodes and edges given in l *)
-val of_edges : (Vertex.t * Vertex.t) list -> t
+val of_edges : Edge.t list -> t
 
 (** add_edges g l adds all directed edges in l to g *)
 val add_edges : t -> Edge.t list -> t

--- a/src/lib/datastructures/AdjGraph.mli
+++ b/src/lib/datastructures/AdjGraph.mli
@@ -1,13 +1,17 @@
+
 module Vertex :
   sig
+    (* include module type of Graph.Pack.Graph.V *)
     type t = int (* Really should be Syntax.node, but that causes a dependency loop *)
 
     val printVertex : t -> string
     val compare : t -> t -> int
     val equal : t -> t -> bool
     val hash : t -> int
-    val of_int : int -> t
   end
+
+(* graph *)
+include module type of Graph.Persistent.Graph.Concrete (Vertex)
 
 module Edge : Map.OrderedType with type t = Vertex.t * Vertex.t
 
@@ -32,10 +36,6 @@ val vertex_map_to_string : ('a -> string) -> 'a VertexMap.t -> string
 
 val print_vertex_map : ('a -> string) -> 'a VertexMap.t -> unit
 
-(* graph *)
-(* include module type of Graph.Persistent.Graph.Concrete (Vertex) *)
-include module type of Graph.Pack.Graph
-
 (* raise BadVertex if a vertex v does not belong to a graph's set of vertices, ie: 0..num_vertex-1 *)
 
 exception BadVertex of Vertex.t
@@ -45,10 +45,9 @@ val good_vertex : t -> Vertex.t -> unit
 val good_graph : t -> unit
 
 (* create a graph with i vertices named 0..i-1 *)
-(* val create : int -> t *)
+val create : int -> t
 
 (* number of vertices in the graph (named 0..i-1) *)
-
 val num_vertices : t -> int
 
 val fold_vertices : (Vertex.t -> 'a -> 'a) -> Vertex.t -> 'a -> 'a

--- a/src/lib/datastructures/dune
+++ b/src/lib/datastructures/dune
@@ -2,6 +2,7 @@
  (name nv_datastructures)
  ; (public_name nv.datastructures)
  (libraries
+    nv_utils
     integers
     ocamlgraph
     batteries

--- a/src/lib/lang/Printing.ml
+++ b/src/lib/lang/Printing.ml
@@ -341,7 +341,7 @@ let network_to_string ?(show_topology=false) (net : Syntax.network) =
   (if not show_topology then [] else
      let open Nv_datastructures in
      [
-       Printf.sprintf "let nodes = %d\n\n" (AdjGraph.num_vertices net.graph);
+       Printf.sprintf "let nodes = %d\n\n" (AdjGraph.nb_vertex net.graph);
 
        Printf.sprintf "let edges = {%s}\n\n" @@ list_to_string
          (fun (i, j) -> Printf.sprintf "%dn-%dn" i j)

--- a/src/lib/smt/Smt.ml
+++ b/src/lib/smt/Smt.ml
@@ -182,7 +182,7 @@ let solveClassic info query chan ?(params=[]) net =
     (val (module SmtClassicEncoding.ClassicEncoding(ExprEnc) : SmtClassicEncoding.ClassicEncodingSig))
   in
   solve info query chan params (fun () -> Enc.encode_z3 net)
-    (Nv_datastructures.AdjGraph.num_vertices net.graph) net.assertion net.requires
+    (Nv_datastructures.AdjGraph.nb_vertex net.graph) net.assertion net.requires
 
 let solveFunc info query chan ?(params=[]) srp =
   let open Nv_lang.Syntax in
@@ -191,7 +191,7 @@ let solveFunc info query chan ?(params=[]) srp =
     (val (module SmtFunctionalEncoding.FunctionalEncoding(ExprEnc) : SmtFunctionalEncoding.FunctionalEncodingSig))
   in
   solve info query chan params (fun () -> Enc.encode_z3 srp)
-    (Nv_datastructures.AdjGraph.num_vertices srp.srp_graph) srp.srp_assertion srp.srp_requires
+    (Nv_datastructures.AdjGraph.nb_vertex srp.srp_graph) srp.srp_assertion srp.srp_requires
 
 (** For quickcheck smart value generation *)
 let symvar_assign info (net: Nv_lang.Syntax.network) : Nv_lang.Syntax.value VarMap.t option =

--- a/src/lib/smt/SmtCheckProps.ml
+++ b/src/lib/smt/SmtCheckProps.ml
@@ -52,7 +52,7 @@ let checkMonotonicity info query chan net =
   let checka = Boxed.create_strings "checka" net.attr_type in
   let checka_var = Boxed.lift1 Var.create checka in
   let transTable = Nv_transformations.Slicing.partialEvalOverEdges (AdjGraph.edges net.graph) net.trans in
-  let mergeTable = Nv_transformations.Slicing.partialEvalOverNodes (AdjGraph.num_vertices net.graph) net.merge in
+  let mergeTable = Nv_transformations.Slicing.partialEvalOverNodes (AdjGraph.nb_vertex net.graph) net.merge in
   let solver = start_solver [] in
   let unbox x = Boxed.to_list x |> List.hd in
   Hashtbl.iter (fun edge trans ->

--- a/src/lib/smt/SmtCheckProps.ml
+++ b/src/lib/smt/SmtCheckProps.ml
@@ -139,6 +139,6 @@ let checkMonotonicity info query chan net =
       match reply with
       | SAT ->
         Nv_lang.Console.warning (Printf.sprintf "Policy on edge %s is non-monotonic"
-                           (AdjGraph.printEdge edge))
+                           (AdjGraph.Edge.to_string edge))
       | UNSAT -> ()
       | _ -> failwith "unknown answer") transTable

--- a/src/lib/smt/SmtClassicEncoding.ml
+++ b/src/lib/smt/SmtClassicEncoding.ml
@@ -113,7 +113,7 @@ struct
     let eassert = net.assertion in
     let emerge = net.merge in
     let etrans = net.trans in
-    let nodes = (AdjGraph.num_vertices net.graph) in
+    let nodes = (AdjGraph.nb_vertex net.graph) in
     let edges = (AdjGraph.edges net.graph) in
     let aty = net.attr_type in
     (* map each node to the init result variable *)

--- a/src/lib/smt/SmtFunctionalEncoding.ml
+++ b/src/lib/smt/SmtFunctionalEncoding.ml
@@ -58,7 +58,7 @@ struct
     in
     let env = init_solver srp.srp_symbolics ~labels:labels in
     let aty = srp.srp_attr in
-    let nodes = (AdjGraph.num_vertices srp.srp_graph) in
+    let nodes = (AdjGraph.nb_vertex srp.srp_graph) in
 
     let smt_labels =
       AdjGraph.VertexMap.map

--- a/src/lib/smt/SmtHiding.ml
+++ b/src/lib/smt/SmtHiding.ml
@@ -493,7 +493,7 @@ let solve_hiding info query partial_chan ~full_chan ?(params=[]) ?(starting_vars
   ask_solver_blocking partial_solver partial_encoding;
   ask_solver_blocking full_solver full_encoding;
 
-  let nodes = Nv_datastructures.AdjGraph.num_vertices net.graph in
+  let nodes = Nv_datastructures.AdjGraph.nb_vertex net.graph in
   let ask_for_nv_model solver =
     ask_for_model query partial_chan info full_env solver renaming nodes net.assertion
   in

--- a/src/lib/smt/SmtSrp.ml
+++ b/src/lib/smt/SmtSrp.ml
@@ -41,7 +41,7 @@ let network_to_srp (net : network) =
         (*create label var *)
         let lbl_var = Var.create lbl_u_name in
         AdjGraph.VertexMap.add u [(lbl_var, net.attr_type)] acc)
-      (AdjGraph.num_vertices net.graph) AdjGraph.VertexMap.empty
+      (AdjGraph.nb_vertex net.graph) AdjGraph.VertexMap.empty
   in
   (* Map from nodes to incoming messages*)
   let incoming_messages_map =
@@ -66,7 +66,7 @@ let network_to_srp (net : network) =
         let best_eval = InterpPartialFull.interp_partial best in
         (* Printf.printf "merge after interp:\n%s\n" (Printing.exp_to_string best_eval); *)
         AdjGraph.VertexMap.add u best_eval acc)
-      (AdjGraph.num_vertices net.graph) AdjGraph.VertexMap.empty
+      (AdjGraph.nb_vertex net.graph) AdjGraph.VertexMap.empty
   in
   { srp_attr = net.attr_type;
     srp_constraints = merged_messages_map;

--- a/src/lib/transformations/Failures.ml
+++ b/src/lib/transformations/Failures.ml
@@ -60,7 +60,7 @@ let buildSymbolicFailures (aedges : AdjGraph.Edge.t list) (k : int) =
   let open AdjGraph in
   let failuresMap =
     BatList.fold_left (fun acc (u,v) ->
-        let e = Printf.sprintf "%s-%s" (Vertex.printVertex u) (Vertex.printVertex v) in
+        let e = Printf.sprintf "%s-%s" (Vertex.to_string u) (Vertex.to_string v) in
         let failVar = Var.fresh ("failed-" ^ e) in
         EdgeMap.add (u,v) failVar acc) EdgeMap.empty aedges in
   let failures_leq_k = failuresConstraint_pb k failuresMap in

--- a/src/lib/transformations/Slicing.ml
+++ b/src/lib/transformations/Slicing.ml
@@ -163,7 +163,7 @@ let createNetwork decls =
 (* Need to have inlined definitions before calling this *)
 let createSlices _info net =
   let open Syntax in
-  let n = AdjGraph.num_vertices net.graph in
+  let n = AdjGraph.nb_vertex net.graph in
   let initMap = partialEvalOverNodes n net.init in
   let assertMap = partialEvalOverNodes n (Nv_utils.OCamlUtils.oget net.assertion) in
   (* find the prefixes that are relevant to the assertions *)

--- a/src/lib/utils/PrimitiveCollections.ml
+++ b/src/lib/utils/PrimitiveCollections.ml
@@ -39,8 +39,8 @@ module BetterSet = struct
   end
 
   module type S = sig
-    include Map.S
-    val to_string : 'a t -> string
+    include Set.S
+    val to_string : t -> string
   end
 
   module Make (E : EltType) = struct


### PR DESCRIPTION
Replace current implementation of `AdjGraph` with one partially derived from `ocamlgraph`'s [`Persistent.Graph.Concrete`](http://ocamlgraph.lri.fr/doc/Persistent.S.Concrete.html) module, using our custom `Vertex` type. In a few cases, this changes the names of functions we use, e.g. `add_edge` vs `add_edge_e`, but mostly everything looks the same from an API perspective as before.

This PR closes #12.