### PR TITLE
TSet and TGet operations for SMT

### DIFF
--- a/src/lib/Main_defs.ml
+++ b/src/lib/Main_defs.ml
@@ -46,17 +46,12 @@ let run_smt_func file cfg info net fs =
   in
   let srp, f = Renaming.alpha_convert_srp srp in
   let srp, fs =
-    if cfg.unbox then
-      begin
-        SmtUtils.smt_config.unboxing <- true;
-        let srp, f1 = Profile.time_profile "Unbox options" (fun () -> UnboxOptions.unbox_srp srp) in
-        let srp, f2 =
-          Profile.time_profile "Flattening Tuples" (fun () -> TupleFlatten.flatten_srp srp)
-        in
-        srp, (f2 :: f1 :: f :: fs)
-      end
-    else
-      srp, f :: fs
+    SmtUtils.smt_config.unboxing <- true;
+    let srp, f1 = Profile.time_profile "Unbox options" (fun () -> UnboxOptions.unbox_srp srp) in
+    let srp, f2 =
+      Profile.time_profile "Flattening Tuples" (fun () -> TupleFlatten.flatten_srp srp)
+    in
+    srp, (f2 :: f1 :: f :: fs)
   in
   let res = Smt.solveFunc info cfg.query (smt_query_file file) srp in
   match res with
@@ -74,16 +69,12 @@ let run_smt_func file cfg info net fs =
 
 let run_smt_classic file cfg info (net : Syntax.network) fs =
   let net, fs =
-    if cfg.unbox then
-      begin
-        SmtUtils.smt_config.unboxing <- true;
-        let net, f1 = Profile.time_profile "Unbox options" (fun () -> UnboxOptions.unbox_net net) in
-        let net, f2 =
-          Profile.time_profile "Flattening Tuples" (fun () -> TupleFlatten.flatten_net net)
-        in
-        net, (f2 :: f1 :: fs)
-      end
-    else net, fs
+    SmtUtils.smt_config.unboxing <- true;
+    let net, f1 = Profile.time_profile "Unbox options" (fun () -> UnboxOptions.unbox_net net) in
+    let net, f2 =
+      Profile.time_profile "Flattening Tuples" (fun () -> TupleFlatten.flatten_net net)
+    in
+    net, (f2 :: f1 :: fs)
   in
   (* let net = {net with trans = InterpPartial.interp_partial net.trans} in
    * Printf.printf "%s\n" (Printing.network_to_string net); *)

--- a/src/lib/interpreter/Interp.ml
+++ b/src/lib/interpreter/Interp.ml
@@ -94,12 +94,12 @@ and interp_op env ty op es =
     if n1 < n2 then vbool true else vbool false
   | NLeq, [{v= VNode n1}; {v= VNode n2}] ->
     if n1 <= n2 then vbool true else vbool false
-  | TGet (size, lo, hi), [{v= VTuple elts}] ->
-    assert (List.length elts = size) ; (* Sanity check *)
+  | TGet (_, lo, hi), [{v= VTuple elts}] ->
+    (* assert (List.length elts = size) ; (\* Sanity check *\) *)
     if lo = hi then List.nth elts lo
     else vtuple (elts |> BatList.drop lo  |> BatList.take (hi - lo + 1))
-  | TSet (size, lo, hi), [{v= VTuple elts}; v] ->
-    assert (List.length elts = size) ; (* Sanity check *)
+  | TSet (_, lo, hi), [{v= VTuple elts}; v] ->
+    (* assert (List.length elts = size) ; (\* Sanity check *\) *)
     begin
       if lo = hi then
         vtuple (BatList.modify_at lo (fun _ -> v) elts)
@@ -107,7 +107,7 @@ and interp_op env ty op es =
         match v.v with
         | VTuple velts ->
           let hd, rest = BatList.takedrop lo elts in
-          let _, tl = BatList.takedrop (hi - lo + 1) rest in
+          let tl = BatList.drop (hi - lo + 1) rest in
           vtuple (hd @ velts @ tl)
         | _ -> failwith "Bad TSet"
     end

--- a/src/lib/lang/Cmdline.ml
+++ b/src/lib/lang/Cmdline.ml
@@ -77,7 +77,7 @@ let set_cfg c = cfg := c
    appropriate flags are set, so we don't have to check for lots of different
    variables at the site of each transformation *)
 let update_cfg_dependencies () =
-  if !cfg.smt then cfg := {!cfg with unroll=true; inline=true};
+  if !cfg.smt then cfg := {!cfg with unroll=true; unbox=true; inline=true};
   if !cfg.unroll then cfg := {!cfg with inline=true};
   if !cfg.check_monotonicity then cfg := {!cfg with inline=true};
   if !cfg.smart_gen then cfg := {!cfg with inline=true};

--- a/src/lib/smt/SmtUnboxed.ml
+++ b/src/lib/smt/SmtUnboxed.ml
@@ -250,6 +250,20 @@ struct
          let ze1 = encode_exp_z3 descr env e1 in
          let ze2 = encode_exp_z3 descr env e2 in
          lift2 (fun ze1 ze2 -> mk_eq ze1.t ze2.t |> mk_term ~tloc:e.espan) ze1 ze2
+       | TGet (_, lo, hi), [e1] when lo < hi ->
+         let ze1 = encode_exp_z3 descr env e1 in
+         ze1 |> BatList.drop lo |> BatList.take (hi - lo + 1)
+       | TGet (_, lo, _), [e1] (*lo = hi*) ->
+         let ze1 = encode_exp_z3 descr env e1 in
+         [BatList.nth ze1 lo]
+       | TSet (_, lo, hi), [e1; e2] when lo < hi ->
+         let ze1 = encode_exp_z3 descr env e1 in
+         let ze2 = encode_exp_z3 descr env e2 in
+         replaceSlice lo hi ze1 ze2
+       | TSet (_, lo, _), [e1; e2] (*lo=hi*) ->
+         let ze1 = encode_exp_z3 descr env e1 in
+         let ze2 = encode_exp_z3_single descr env e2 in
+         BatList.modify_at lo (fun _ -> ze2) ze1
        | _ -> [encode_exp_z3_single descr env e])
     | EVal v when (match v.vty with | Some (TTuple _) -> true | _ -> false) ->
       encode_value_z3 descr env v

--- a/src/lib/utils/OCamlUtils.ml
+++ b/src/lib/utils/OCamlUtils.ml
@@ -47,6 +47,15 @@ let rec combine3 lst1 lst2 lst3 =
   | hd1::tl1, hd2::tl2, hd3::tl3 -> (hd1,hd2,hd3)::combine3 tl1 tl2 tl3
   | _ -> raise (Invalid_argument "combine3: lists have different lengths")
 
+
+let replaceSlice lo hi ls slice =
+  BatList.fold_righti (fun i x (vs, acc) ->
+      if (i >= lo && i <= hi) then
+        (BatList.tl vs, (BatList.hd vs) :: acc)
+      else
+        (vs, x :: acc)
+    ) ls (BatList.rev slice, []) |> snd
+
 let printList (printer: 'a -> string) (ls: 'a list) (first : string)
               (sep : string) (last : string) =
   let buf = Buffer.create 500 in

--- a/test/Test_end_to_end.ml
+++ b/test/Test_end_to_end.ml
@@ -172,37 +172,6 @@ let compiler_tests =
     ]
 ;;
 
-let smt_tests =
-  List.map (fun (f,b) -> smt_test f b)
-    [
-      ("examples/debugging/debug-combine.nv", true);
-      (* Takes forever? *)
-      (* ("examples/batfish.nv", false); *)
-      ("examples/diamond.nv", true);
-      ("examples/diamond-ospf.nv", true);
-      ("examples/env.nv", true);
-      ("examples/failure.nv", false);
-      ("examples/failure2.nv", false);
-      (* ("examples/fattree.nv", true); *)
-      ("examples/map.nv", true);
-      ("examples/map2.nv", false);
-      ("examples/minesweeper.nv", false);
-      ("examples/property.nv", true);
-      ("examples/set.nv", true);
-      ("examples/simple.nv", true);
-      ("examples/symbolic.nv", false);
-      ("examples/symbolic2.nv", false);
-      ("examples/maprecord.nv", true);
-      ("examples/maprecordpattern.nv", true);
-      ("examples/maprecord2.nv", true);
-      ("examples/record.nv", true);
-      ("examples/recordwith.nv", true);
-
-      ("examples/symbolic3.nv", false);
-      ("examples/symbolicDecls.nv", false);
-      ("examples/ospf-areas.nv", true);
-    ]
-;;
 
 let unboxed_tests =
   List.map (fun (f,b) -> unboxed_test f b)
@@ -325,7 +294,6 @@ let tests =
   >:::
   List.map make_ounit_test @@
   simulator_tests @
-  smt_tests @
   unboxed_tests @
   hiding_tests @
   slicing_tests @


### PR DESCRIPTION
- Adds support for encoding TSet and TGet operations in SMT using the unboxed encoding. The code that creates the SMT encoding is not optimal right now, but if it's a big issue we can revisit it.
- Simplifies the partial interpreter for TSet and TGet as it no longer needs to create match expressions.
- Removes support for the boxed encoding, as discussed it is not very useful. It is still there, but no longer accessible. The default SMT encoding is unboxed.
- Tests succeed, but I haven't done further testing.